### PR TITLE
Added links to model converters.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,6 +348,17 @@ Tensorboard
 .. _Tensorboard Explained in 5 Min: https://www.youtube.com/watch?v=3bownM3L5zM
 .. _How to Use Tensorboard: https://www.youtube.com/watch?v=fBVEXKp4DIc
 
+
+~~~~~~~~~~
+Converters
+~~~~~~~~~~
+
+* `Convert PyTorch model to the Keras model`_: Non-official pytorch2keras converter
+* `Convert Gluon model to the Keras model`_: Non-official gluon2keras converter
+
+.. _Convert PyTorch model to the Keras model: https://github.com/nerox8664/pytorch2keras
+.. _Convert Gluon model to the Keras model: https://github.com/nerox8664/gluon2keras
+
 ====================
 TensorFlow Tutorials
 ====================


### PR DESCRIPTION
Hello.
I added links to these model converters:
* [pytorch2keras](https://github.com/nerox8664/pytorch2keras) - Convert PyTorch models to Keras (with TensorFlow backend) format
* [gluon2keras](https://github.com/nerox8664/gluon2keras) - Convert Gluon models to Keras (with TensorFlow backend) format